### PR TITLE
Migrating from slackclient to slack_sdk python3 library

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ JSMON_TELEGRAM_TOKEN=YOUR TELEGRAM TOKEN
 JSMON_TELEGRAM_CHAT_ID=YOUR TELEGRAM CHAT ID
 #JSMON_NOTIFY_SLACK=True
 #JSMON_SLACK_TOKEN=sometoken
-#JSMON_SLACK_CHANNEL_ID=somechannel
+#JSMON_SLACK_CHANNEL_ID=somechannel_ID
 ```
-To Enable slack, uncomment the slack lines in the env and add your token.
+To Enable slack, uncomment the slack lines in the env and add your token (`JSMON_SLACK_CHANNEL_ID` should be in the form of: C04P1XXXXXX).
 
 To create a cron script to run JSMon regularly:
 ```

--- a/jsmon.py
+++ b/jsmon.py
@@ -17,8 +17,8 @@ SLACK_CHANNEL_ID = config("JSMON_SLACK_CHANNEL_ID", default="CHANGEME")
 NOTIFY_SLACK = config("JSMON_NOTIFY_SLACK", default=False, cast=bool)
 NOTIFY_TELEGRAM = config("JSMON_NOTIFY_TELEGRAM", default=False, cast=bool)
 if NOTIFY_SLACK:
-    from slack import WebClient
-    from slack.errors import SlackApiError
+    from slack_sdk import WebClient
+    from slack_sdk.errors import SlackApiError
     if(SLACK_TOKEN == "CHANGEME"):
         print("ERROR SLACK TOKEN NOT FOUND!")
         exit(1)
@@ -130,7 +130,7 @@ def notify_telegram(endpoint,prev, new, diff, prevsize,newsize):
 
 def notify_slack(endpoint,prev, new, diff, prevsize,newsize):
     try:
-        response = client.files_upload(
+        response = client.files_upload_v2(
             initial_comment = "[JSmon] {} has been updated! Download below diff HTML file to check changes.".format(endpoint),
             channels = SLACK_CHANNEL_ID,
             content = diff,

--- a/setup.py
+++ b/setup.py
@@ -11,5 +11,5 @@ setup(
     author_email='mail@r0b.re',
     license='MIT',
     url='https://github.com/robre/jsmon',
-    install_requires=['requests', 'jsbeautifier', 'python-decouple','slackclient'],
+    install_requires=['requests', 'jsbeautifier', 'python-decouple','slack_sdk'],
 )


### PR DESCRIPTION
Migrating from slackclient to slack_sdk according to the documentation: [https://slack.dev/python-slack-sdk/v3-migration/index.html](https://slack.dev/python-slack-sdk/v3-migration/index.html)

The `JSMON_SLACK_CHANNEL_ID` variable now should be in the form of channel_id instead of channel name. 